### PR TITLE
Update Title generator to comply with several appendixes of DCNC v.9.3

### DIFF
--- a/gui/resources/naming.xml
+++ b/gui/resources/naming.xml
@@ -215,6 +215,7 @@ ZA    SOUTH AFRICA
 </territory>
 
 <rating>
+NR    NOT RATED
 G     General Admission
 PG    Parental Guidance
 13    PG-13

--- a/gui/resources/naming.xml
+++ b/gui/resources/naming.xml
@@ -306,12 +306,11 @@ Y7    YELLOW CIRCLE 7
 </rating>
 
 <audio>
-NS    No Sound
+MOS   No Audio (Silent)
 51    5.1
-61    6.1
 71    7.1
-10    Center Channel Mono
-20    LtRt Stereo
+10    1.0 (Center Channel Mono)
+20    2.0 (LoRo Stereo)
 </audio>
 
 <resolution>

--- a/gui/resources/naming.xml
+++ b/gui/resources/naming.xml
@@ -95,6 +95,8 @@ YUE    CHINESE - CANTONESE
 </language>
 
 <territory>
+INT-TD    International Texted
+INT-TL    International Texted
 AE    UNITED ARAB EMIRATES
 AL    ALBANIA
 AN    CURACAO

--- a/gui/resources/naming.xml
+++ b/gui/resources/naming.xml
@@ -96,7 +96,7 @@ YUE    CHINESE - CANTONESE
 
 <territory>
 INT-TD    International Texted
-INT-TL    International Texted
+INT-TL    International Textless
 AE    UNITED ARAB EMIRATES
 AL    ALBANIA
 AN    CURACAO


### PR DESCRIPTION
I've updated several of the naming conventions to comply with the most recent version of the DCNC. In particular, it adds a NR rating (the films I do haven't been reviewed by a Film Review Board), adds an International Texted and Textless option for films that do not have country/territory specific releases and changes the channel naming to reflect current standards.