### PR TITLE
Fix bug in 'opendcp_decoder_openexr.c' and add float functions for 'opendcp_image'

### DIFF
--- a/libopendcp/codecs/opendcp_decoder_openexr.c
+++ b/libopendcp/codecs/opendcp_decoder_openexr.c
@@ -341,16 +341,16 @@ exr_attributes read_attributes( FILE *exr_fp ) {
          else if( !strcmp( "compression", attribute_name ) )
              attributes.compression = fgetc( exr_fp );
         else if( !strcmp( "dataWindow", attribute_name ) ) {
-           fread( &(attributes.dataWindow.left), 4, 1, exr_fp );
-           fread( &(attributes.dataWindow.bottom), 4, 1, exr_fp );
-           fread( &(attributes.dataWindow.right), 4, 1, exr_fp );
-           fread( &(attributes.dataWindow.top), 4, 1, exr_fp );
+           fread( &(attributes.data_window.left), 4, 1, exr_fp );
+           fread( &(attributes.data_window.bottom), 4, 1, exr_fp );
+           fread( &(attributes.data_window.right), 4, 1, exr_fp );
+           fread( &(attributes.data_window.top), 4, 1, exr_fp );
         }
         else if( !strcmp( "displayWindow", attribute_name ) ) {
-           fread( &(attributes.displayWindow.left), 4, 1, exr_fp );
-           fread( &(attributes.displayWindow.bottom), 4, 1, exr_fp );
-           fread( &(attributes.displayWindow.right), 4, 1, exr_fp );
-           fread( &(attributes.displayWindow.top), 4, 1, exr_fp );
+           fread( &(attributes.display_Window.left), 4, 1, exr_fp );
+           fread( &(attributes.display_Window.bottom), 4, 1, exr_fp );
+           fread( &(attributes.display_window.right), 4, 1, exr_fp );
+           fread( &(attributes.display_window.top), 4, 1, exr_fp );
         }
         else
          // ---- skip attribute
@@ -368,7 +368,7 @@ exr_attributes read_attributes( FILE *exr_fp ) {
 exr_chunk_data read_chunk_data( FILE *exr_fp, exr_attributes *attributes ) {
 
    exr_chunk_data chunk_data;
-   unsigned short num_rows = (attributes->dataWindow.top - attributes->dataWindow.bottom) + 1;
+   unsigned short num_rows = (attributes->data_window.top - attributes->data_window.bottom) + 1;
 
    // ---- if EXR_COMPRESSION_ZIP, 16 rows per chunk
    if( attributes->compression == EXR_COMPRESSION_ZIP ) { //
@@ -576,7 +576,7 @@ void copy_float_data( unsigned char *buffer, float *channel_data, unsigned short
 /* compression no */
 void read_data_compression_no( FILE *exr_fp, exr_chunk_data *chunk_data, exr_attributes *attributes, exr_image_data *image_data ) {
 
-   unsigned int num_columns = (attributes->dataWindow.right - attributes->dataWindow.left) + 1;
+   unsigned int num_columns = (attributes->data_window.right - attributes->data_window.left) + 1;
   
    unsigned short channel_data_width = attributes->channel_list.data_width;
 
@@ -622,7 +622,7 @@ void read_data_compression_no( FILE *exr_fp, exr_chunk_data *chunk_data, exr_att
 /* compression RLE */
 void read_data_compression_rle( FILE *exr_fp, exr_chunk_data *chunk_data, exr_attributes *attributes, exr_image_data *image_data ) {
 
-   unsigned int num_columns = (attributes->dataWindow.right - attributes->dataWindow.left) + 1;
+   unsigned int num_columns = (attributes->data_window.right - attributes->data_window.left) + 1;
   
    unsigned short channel_data_width = attributes->channel_list.data_width;
 
@@ -683,7 +683,7 @@ void read_data_compression_rle( FILE *exr_fp, exr_chunk_data *chunk_data, exr_at
 /* compression ZIPS an ZIP */
 void read_data_compression_zip( FILE *exr_fp, exr_chunk_data *chunk_data, exr_attributes *attributes, exr_image_data *image_data ) {
 
-   unsigned int num_columns = (attributes->dataWindow.right - attributes->dataWindow.left) + 1;
+   unsigned int num_columns = (attributes->data_window.right - attributes->data_window.left) + 1;
    unsigned char num_rows = 1;
    unsigned char *compressed_buffer = NULL;
    unsigned char *uncompressed_buffer = NULL;
@@ -830,8 +830,8 @@ int opendcp_decode_exr(opendcp_image_t **image_ptr, const char *sfile) {
 
     // ---- for store image data
    exr_image_data image_data;
-   image_data.width = attributes.dataWindow.right - attributes.dataWindow.left + 1;
-   image_data.height = attributes.dataWindow.top - attributes.dataWindow.bottom + 1;
+   image_data.width = attributes.data_window.right - attributes.data_window.left + 1;
+   image_data.height = attributes.data_window.top - attributes.data_window.bottom + 1;
    // ---- create buffers for image data
    image_data.channel_b = malloc( image_data.width*image_data.height * sizeof( float ) );
    image_data.channel_g = malloc( image_data.width*image_data.height * sizeof( float ) );
@@ -849,15 +849,17 @@ int opendcp_decode_exr(opendcp_image_t **image_ptr, const char *sfile) {
    fclose( exr_fp );
  
     /* create the image (float data) */
-   image = opendcp_image_create_float(3, image_data.width, mage_data.height);
+   opendcp_image_t *image = opendcp_image_create_float(3, image_data.width, image_data.height);
   
    unsigned int image_size = image_data.width * mage_data.height;
-   for (index = 0; index < image_size; index++) {
+   unsigned int index = 0;
+   while( index < image_size ) {
     // ---- need copy float data from exr image data to float opendcp image data
       // ----- correct channel order?
       image->component[0].float_data[index] = image_data.channel_b[index];
       image->component[1].float_data[index] = image_data.channel_g[index];
       image->component[2].float_data[index] = image_data.channel_r[index];
+      index++;
    }
  
    // ---- free chunk table

--- a/libopendcp/codecs/opendcp_decoder_openexr.c
+++ b/libopendcp/codecs/opendcp_decoder_openexr.c
@@ -73,7 +73,7 @@ typedef enum {
 
 typedef struct {
     char name[255];            /* channel name                                      */
-    unsigned char dataType;    /* channel data type, int, half, float               */
+    unsigned char data_type;   /* channel data type, int, half, float               */
     unsigned char non_linear;  /* non linear, only use for B44 and B44A compression */
     unsigned int sample_x;     /* sample x direction, only support == 1             */
     unsigned int sample_y;     /* sample y direction, only support == 1             */
@@ -98,7 +98,8 @@ typedef struct {
 typedef struct {
     exr_channel_list channel_list;    /* channel list */
     unsigned char compression;        /* compression */
-    exr_window dataWindow;            /* data window */
+    exr_window data_window;           /* data window */
+    exr_window display_window;        /* display window */
 } exr_attributes;
 
 /* exr chunk data */

--- a/libopendcp/opendcp_image.c
+++ b/libopendcp/opendcp_image.c
@@ -33,7 +33,7 @@ extern int rgb_to_xyz_calculate(opendcp_image_t *image, int index);
 extern int rgb_to_xyz_calculate_float(opendcp_image_t *image, int index);
 extern int rgb_to_xyz_lut(opendcp_image_t *image, int index);
 
-/* create opendcp image structure for int */
+/* create opendcp image structure (int data) */
 opendcp_image_t *opendcp_image_create(int n_components, int w, int h) {
     int x;
     opendcp_image_t *image = 00;
@@ -83,7 +83,7 @@ opendcp_image_t *opendcp_image_create(int n_components, int w, int h) {
 }
 
 /* create opendcp image structure for float */
-opendcp_image_t *opendcp_image_float_create(int n_components, int w, int h) {
+opendcp_image_t *opendcp_image_create_float(int n_components, int w, int h) {
     int x;
     opendcp_image_t *image = 00;
 
@@ -473,12 +473,24 @@ float complex_gamma_float(float p, float gamma, int index) {
     return v;
 }
 
+/* adjust headroom (int data) */
 int adjust_headroom(int p) {
     if (p < HEADROOM * 3)  {
         return  p - HEADROOM;
     }
 
     return p;
+}
+
+/* adjust headroom (float data) */
+float adjust_headroom_float(float p) {
+   float h = HEADROOM/4095.0;
+   
+   if (p < h * 3)  {
+      return  p - h;
+   }
+   
+   return p;
 }
 
 /* dci transfer (int data) */

--- a/libopendcp/opendcp_image.c
+++ b/libopendcp/opendcp_image.c
@@ -498,7 +498,7 @@ float dci_transfer_float(float p) {
 
     v = pow((p * DCI_COEFFICENT), DCI_DEGAMMA);
     // adjust value below full color pixel?
-    v -= HEADROOM/4096.0f;  //<---- assume int data function give 12 bit data
+    v -= HEADROOM/4095.0f;  //<---- assume int data function give 12 bit data
 
     return v;
 }

--- a/libopendcp/opendcp_image.c
+++ b/libopendcp/opendcp_image.c
@@ -82,7 +82,7 @@ opendcp_image_t *opendcp_image_create(int n_components, int w, int h) {
     return image;
 }
 
-/* create opendcp image structure for float */
+/* create opendcp image structure (float data) */
 opendcp_image_t *opendcp_image_create_float(int n_components, int w, int h) {
     int x;
     opendcp_image_t *image = 00;

--- a/libopendcp/opendcp_image.c
+++ b/libopendcp/opendcp_image.c
@@ -505,9 +505,9 @@ int rgb_to_xyz_calculate_float(opendcp_image_t *image, int index) {
     OPENDCP_LOG(LOG_DEBUG, "gamma: %f", GAMMA[index]);
 
     for (i = 0; i < size; i++) {
-        s.r = complex_gamma(image->component[0].float_data[i], GAMMA[index], index);
-        s.g = complex_gamma(image->component[1].float_data[i], GAMMA[index], index);
-        s.b = complex_gamma(image->component[2].float_data[i], GAMMA[index], index);
+        s.r = complex_gamma_float(image->component[0].float_data[i], GAMMA[index], index);
+        s.g = complex_gamma_float(image->component[1].float_data[i], GAMMA[index], index);
+        s.b = complex_gamma_float(image->component[2].float_data[i], GAMMA[index], index);
 
         d.x = ((s.r * color_matrix[index][0][0]) + (s.g * color_matrix[index][0][1]) + (s.b * color_matrix[index][0][2]));
         d.y = ((s.r * color_matrix[index][1][0]) + (s.g * color_matrix[index][1][1]) + (s.b * color_matrix[index][1][2]));

--- a/libopendcp/opendcp_image.h
+++ b/libopendcp/opendcp_image.h
@@ -64,7 +64,10 @@ typedef struct {
     unsigned char use_float;      /* flag for use float */
 } opendcp_image_t;
 
+
 int  read_image(opendcp_image_t **image, char *file);
+
+ /* int data functions */
 void opendcp_image_free(opendcp_image_t *image);
 int opendcp_image_size(opendcp_image_t *opendcp_image);
 int  opendcp_image_readline(opendcp_image_t *image, int y, unsigned char *data);
@@ -72,6 +75,14 @@ int  rgb_to_xyz(opendcp_image_t *image, int gamma, int method);
 int  resize(opendcp_image_t **image, int profile, int method);
 rgb_pixel_float_t yuv444toRGB888(int y, int cb, int cr);
 opendcp_image_t *opendcp_image_create(int n_components, int w, int h);
+    
+/* float data functions */
+void opendcp_image_free_float(opendcp_image_t *opendcp_image);
+int opendcp_image_readline_float(opendcp_image_t *image, int y, unsigned char *dbuffer);
+float rgb_to_xyz_float(opendcp_image_t *image, int index);
+int resize_float(opendcp_image_t **image, int profile, int method);
+rgb_pixel_float_t yuv444toRGB888_float(float y, float cb, float cr);
+opendcp_image_t *opendcp_image_create_float(int n_components, int w, int h);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fix bug in opendcp_decoder_openexr.c and add float functions for opendcp_image.h and opendcp_image.c. Float functions use float image data (range 0.0 to 1.0) replace integer data (0 to 4095) for high dynamic range image. Only opendcp_decoder_openexr.c use it because only OpenEXR have high dynamic range data. If want use integer data for opendcp_decoder_openexr.c change lines:
line 854:
  opendcp_image_t *image = opendcp_image_create(3, image_data.width, image_data.height);
line 861-863:
      image->component[0].data[index] = (int)image_data.channel_b[index]*4095.0;
      image->component[1].data[index] = (int)image_data.channel_g[index]*4095.0;
      image->component[2].data[index] = (int)image_data.channel_r[index]*4095.0;

If find bug please tell me.